### PR TITLE
Use images in stimuli

### DIFF
--- a/experiment/session1.py
+++ b/experiment/session1.py
@@ -1,5 +1,6 @@
 from psychopy import visual, core, event
 from .utils import SESSION1_OBJECTS, get_permutation
+import os
 
 
 SCRAMBLED_REPEATS = 5
@@ -14,7 +15,13 @@ class Session1:
         self.win = visual.Window(color="black", fullscr=False)
 
     def show_object(self, obj_name: str):
-        stim = visual.TextStim(self.win, text=obj_name, color="white", height=0.1)
+        """Display an image corresponding to the given object name."""
+        img_path = os.path.join(os.path.dirname(__file__), "images", f"{obj_name}.png")
+        if os.path.exists(img_path):
+            stim = visual.ImageStim(self.win, image=img_path)
+        else:
+            # Fallback to text if the image is missing
+            stim = visual.TextStim(self.win, text=obj_name, color="white", height=0.1)
         stim.draw()
         self.win.flip()
         core.wait(OBJECT_DURATION)

--- a/experiment/session2.py
+++ b/experiment/session2.py
@@ -1,5 +1,6 @@
 from psychopy import visual, core, event
 from .utils import SESSION2_OBJECTS, get_permutation
+import os
 
 
 SCRAMBLED_REPEATS = 5
@@ -15,7 +16,12 @@ class Session2:
         self.win = visual.Window(color="black", fullscr=False)
 
     def show_object(self, obj_name: str):
-        stim = visual.TextStim(self.win, text=obj_name, color="white", height=0.1)
+        """Display an image corresponding to the given object name."""
+        img_path = os.path.join(os.path.dirname(__file__), "images", f"{obj_name}.png")
+        if os.path.exists(img_path):
+            stim = visual.ImageStim(self.win, image=img_path)
+        else:
+            stim = visual.TextStim(self.win, text=obj_name, color="white", height=0.1)
         stim.draw()
         self.win.flip()
         core.wait(OBJECT_DURATION)


### PR DESCRIPTION
## Summary
- display `ImageStim` if an image file exists for the object
- fallback to `TextStim` when images are missing

## Testing
- `python -m py_compile experiment/session1.py experiment/session2.py`
- `pip install psychopy` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*

------
https://chatgpt.com/codex/tasks/task_e_684d734225f4832090d1bc31d12f2c5e