### PR TITLE
Scale images to use 25% of window width

### DIFF
--- a/experiment/session1.py
+++ b/experiment/session1.py
@@ -1,4 +1,5 @@
 from psychopy import visual, core, event
+from PIL import Image
 from .utils import SESSION1_OBJECTS, get_permutation
 import os
 
@@ -18,7 +19,13 @@ class Session1:
         """Display an image corresponding to the given object name."""
         img_path = os.path.join(os.path.dirname(__file__), "images", f"{obj_name}.png")
         if os.path.exists(img_path):
-            stim = visual.ImageStim(self.win, image=img_path)
+            # Scale image to occupy 25% of window width while preserving aspect ratio
+            with Image.open(img_path) as img:
+                img_w, img_h = img.size
+            win_w, _ = self.win.size
+            target_w = win_w * 0.25
+            target_h = target_w * img_h / img_w
+            stim = visual.ImageStim(self.win, image=img_path, size=(target_w, target_h))
         else:
             # Fallback to text if the image is missing
             stim = visual.TextStim(self.win, text=obj_name, color="white", height=0.1)

--- a/experiment/session2.py
+++ b/experiment/session2.py
@@ -1,4 +1,5 @@
 from psychopy import visual, core, event
+from PIL import Image
 from .utils import SESSION2_OBJECTS, get_permutation
 import os
 
@@ -19,7 +20,13 @@ class Session2:
         """Display an image corresponding to the given object name."""
         img_path = os.path.join(os.path.dirname(__file__), "images", f"{obj_name}.png")
         if os.path.exists(img_path):
-            stim = visual.ImageStim(self.win, image=img_path)
+            # Scale image to occupy 25% of window width while preserving aspect ratio
+            with Image.open(img_path) as img:
+                img_w, img_h = img.size
+            win_w, _ = self.win.size
+            target_w = win_w * 0.25
+            target_h = target_w * img_h / img_w
+            stim = visual.ImageStim(self.win, image=img_path, size=(target_w, target_h))
         else:
             stim = visual.TextStim(self.win, text=obj_name, color="white", height=0.1)
         stim.draw()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 psychopy
+Pillow


### PR DESCRIPTION
## Summary
- scale images relative to window width in both sessions
- import Pillow and update requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d7a0329e0832096f34c7a9ec6515f