### PR TITLE
Fix exit error when pressing Esc

### DIFF
--- a/experiment/session1.py
+++ b/experiment/session1.py
@@ -18,7 +18,6 @@ class Session1:
         event.globalKeys.add(key="escape", func=self._exit)
 
     def _exit(self):
-        self.win.close()
         core.quit()
 
     def show_object(self, obj_name: str):

--- a/experiment/session2.py
+++ b/experiment/session2.py
@@ -19,7 +19,6 @@ class Session2:
         event.globalKeys.add(key="escape", func=self._exit)
 
     def _exit(self):
-        self.win.close()
         core.quit()
 
     def show_object(self, obj_name: str):


### PR DESCRIPTION
## Summary
- remove manual window closing from `_exit` handlers

## Testing
- `python -m experiment.experiment --help` *(fails: ModuleNotFoundError: No module named 'psychopy')*

------
https://chatgpt.com/codex/tasks/task_e_684d7fd61f748320831437da051c7b1f